### PR TITLE
Default Logout URL

### DIFF
--- a/adminlte3/templatetags/adminlte_helpers.py
+++ b/adminlte3/templatetags/adminlte_helpers.py
@@ -11,7 +11,7 @@ register = template.Library()
 
 @register.simple_tag()
 def logout_url():
-    return getattr(settings, 'LOGOUT_URL', '/logout/')
+    return getattr(settings, 'LOGOUT_URL', '/admin/logout/')
 
 
 @register.simple_tag(takes_context=True)


### PR DESCRIPTION
added /admin/ path, Ref issue #19 
Updated the default URL for the template tag to the most common logout route in stead of removing the template tag in the theme files and using the URL tag for admin:logout.