### PR TITLE
(critical): no 'add' pages is opening in django 5.1 

### DIFF
--- a/adminlte3_theme/templates/admin/includes/fieldset.html
+++ b/adminlte3_theme/templates/admin/includes/fieldset.html
@@ -13,8 +13,8 @@
     <div class="card-body">
         {% for line in fieldset %}
         <div
-            class="form-group row form-row{% if line.fields|length_is:'1' and line.errors %} has_error errors{% endif %}{% if not line.has_visible_field %} hidden{% endif %}{% for field in line %}{% if field.field.name %} field-{{ field.field.name }}{% endif %}{% endfor %}">
-            {% if line.fields|length_is:'1' %}{{ line.errors }}{% endif %}
+            class="form-group row form-row{% if line.fields|length == 1 and line.errors %} has_error errors{% endif %}{% if not line.has_visible_field %} hidden{% endif %}{% for field in line %}{% if field.field.name %} field-{{ field.field.name }}{% endif %}{% endfor %}">
+            {% if line.fields|length == 1 %}{{ line.errors }}{% endif %}
             {% for field in line %}
             <label for="{{field.field.name}}" class="col-sm-2 col-form-label">{{ field.label_tag }}</label>
             <div class="col-sm-10">


### PR DESCRIPTION
this is because although the 'length_is' filter was deprecated in 4.2. the code is permanently removed in django 5.1 this is causing critical issue where you cannot open any 'add/update' pages